### PR TITLE
docs: update pkgdown config

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,7 +1,6 @@
 destination: docs/
 template:
-  params:
-    mathjax: true
+  math-rendering: mathjax
 navbar:
   title: jagstargets
   type: default
@@ -17,7 +16,7 @@ navbar:
       href: https://mcmc-jags.sourceforge.net
   structure:
     left: [home, reference, articles, targets, R2jags, JAGS, news]
-    right: [search, github]
+    right: [search, github, lightswitch]
 reference:
 - title: Help
   contents:


### PR DESCRIPTION
- lightswitch
- rotemplate is now aligned with https://pkgdown.r-lib.org/articles/customise.html#math-rendering